### PR TITLE
Enhance error handling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,10 @@
 * The C++ core has been refactorised into a header-only library under `inst/include` (#147 closing #145). Therefore, from now on it is possible to extend the C++ API from another package by listing `simmer` under the `LinkingTo` field in the DESCRIPTION file.
 * New generic `monitor` constructor enables the development of new monitoring backends in other packages (179f656, as part of #147).
 
+## Minor changes and fixes:
+
+* Enhanced exception handling, with more informative error messages (#148).
+
 # simmer 3.8.0
 
 ## New features:

--- a/inst/include/simmer/activity/arrival.h
+++ b/inst/include/simmer/activity/arrival.h
@@ -31,7 +31,7 @@ namespace simmer {
       VEC<double> vals = get<VEC<double> >(values, arrival);
 
       if (ks.size() != vals.size())
-        Rcpp::stop("%s: number of keys and values don't match", name);
+        Rcpp::stop("number of keys and values don't match");
 
       if (op) {
         for (unsigned int i = 0; i < ks.size(); i++) {
@@ -72,7 +72,7 @@ namespace simmer {
     double run(Arrival* arrival) {
       VEC<int> ret = get<VEC<int> >(values, arrival);
       if (ret.size() != 3)
-        Rcpp::stop("%s: 3 values needed", name);
+        Rcpp::stop("3 values needed, %u received", ret.size());
 
       if (op) {
         ret[0] = op(arrival->order.get_priority(), ret[0]);

--- a/inst/include/simmer/activity/branch.h
+++ b/inst/include/simmer/activity/branch.h
@@ -28,7 +28,7 @@ namespace simmer {
     double run(Arrival* arrival) {
       int ret = get<int>(option, arrival);
       if (ret < 0 || ret > (int)heads.size())
-        Rcpp::stop("%s: index out of range", name);
+        Rcpp::stop("index out of range");
       if (ret) selected = heads[ret-1];
       return 0;
     }

--- a/inst/include/simmer/activity/timeout.h
+++ b/inst/include/simmer/activity/timeout.h
@@ -25,7 +25,7 @@ namespace simmer {
     double run(Arrival* arrival) {
       double value = get<double>(delay, arrival);
       if (ISNAN(value))
-        Rcpp::stop("%s: missing value (NA or NaN returned)", name);
+        Rcpp::stop("missing value (NA or NaN returned)");
       return std::abs(value);
     }
 

--- a/inst/include/simmer/activity/utils/resgetter.h
+++ b/inst/include/simmer/activity/utils/resgetter.h
@@ -22,8 +22,7 @@ namespace simmer { namespace internal {
       if (id < 0)
         selected = arrival->sim->get_resource(resource);
       else selected = arrival->get_resource_selected(id);
-      if (!selected)
-        Rcpp::stop("%s: %s(%s, %i): no resource selected", arrival->name, activity, resource, id);
+      if (!selected) Rcpp::stop("no resource selected");
       return selected;
     }
 

--- a/inst/include/simmer/process/arrival.h
+++ b/inst/include/simmer/process/arrival.h
@@ -68,8 +68,8 @@ namespace simmer {
       if (sim->verbose) {
         Rcpp::Rcout <<
           FMT(10, right) << sim->now() << " |" <<
-            FMT(12, right) << "arrival: " << FMT(15, left) << name << "|" <<
-              FMT(12, right) << "activity: " << FMT(15, left) << activity->name << "| ";
+          FMT(12, right) << "arrival: " << FMT(15, left) << name << "|" <<
+          FMT(12, right) << "activity: " << FMT(15, left) << activity->name << "| ";
         activity->print(0, false, true);
       }
 

--- a/inst/include/simmer/process/datasrc.h
+++ b/inst/include/simmer/process/datasrc.h
@@ -57,21 +57,21 @@ namespace simmer {
 
     void set_source(const ANY& new_source) {
       if (new_source.type() != typeid(RData))
-        Rcpp::stop("source '%s': requires a data frame", name);
+        Rcpp::stop("data frame required");
       source = boost::any_cast<RData>(new_source);
 
       VEC<std::string> n = source.names();
       if (std::find(n.begin(), n.end(), col_time) == n.end())
-        Rcpp::stop("source '%s': column '%s' not present", name, col_time);
+        Rcpp::stop("column '%s' not present", col_time);
       if (col_priority && std::find(n.begin(), n.end(), *col_priority) == n.end())
-        Rcpp::stop("source '%s': column '%s' not present", name, *col_priority);
+        Rcpp::stop("column '%s' not present", *col_priority);
       if (col_preemptible && std::find(n.begin(), n.end(), *col_preemptible) == n.end())
-        Rcpp::stop("source '%s': column '%s' not present", name, *col_preemptible);
+        Rcpp::stop("column '%s' not present", *col_preemptible);
       if (col_restart && std::find(n.begin(), n.end(), *col_restart) == n.end())
-        Rcpp::stop("source '%s': column '%s' not present", name, *col_restart);
+        Rcpp::stop("column '%s' not present", *col_restart);
       for (size_t i = 0; i < col_attrs.size(); ++i) {
         if (std::find(n.begin(), n.end(), col_attrs[i]) == n.end())
-          Rcpp::stop("source '%s': column '%s' not present", name, col_attrs[i]);
+          Rcpp::stop("column '%s' not present", col_attrs[i]);
       }
     }
 

--- a/inst/include/simmer/process/generator.h
+++ b/inst/include/simmer/process/generator.h
@@ -23,7 +23,7 @@ namespace simmer {
 
     void set_source(const ANY& new_source) {
       if (new_source.type() != typeid(RFn))
-        Rcpp::stop("source '%s': requires a function", name);
+        Rcpp::stop("function required");
       source = boost::any_cast<RFn>(new_source);
     }
 

--- a/inst/include/simmer/process/manager.h
+++ b/inst/include/simmer/process/manager.h
@@ -19,9 +19,9 @@ namespace simmer {
     void run() {
       if (sim->verbose) Rcpp::Rcout <<
         FMT(10, right) << sim->now() << " |" <<
-          FMT(12, right) << "manager: " << FMT(15, left) << name << "|" <<
-            FMT(12, right) << "parameter: " << FMT(15, left) << param << "| " <<
-              value[index] << std::endl;
+        FMT(12, right) << "manager: " << FMT(15, left) << name << "|" <<
+        FMT(12, right) << "parameter: " << FMT(15, left) << param << "| " <<
+        value[index] << std::endl;
 
       set(value[index]);
       index++;

--- a/inst/include/simmer/resource/priority.h
+++ b/inst/include/simmer/resource/priority.h
@@ -115,9 +115,9 @@ namespace simmer {
       if (verbose) verbose_print(time, arrival->name, "DEPART");
       typename ServerMap::iterator search = server_map.find(arrival);
       if (search == server_map.end())
-        Rcpp::stop("%s: release: not previously seized", name);
+        Rcpp::stop("'%s' not previously seized", name);
       if (search->second->amount < amount)
-        Rcpp::stop("%s: release: incorrect amount (%d)", name, amount);
+        Rcpp::stop("incorrect amount for '%s' (%d)", name, amount);
       else if (amount < 0 || amount == search->second->amount) {
         server_count -= search->second->amount;
         amount = search->second->amount;

--- a/inst/include/simmer/simulator_impl.h
+++ b/inst/include/simmer/simulator_impl.h
@@ -208,7 +208,17 @@ namespace simmer {
     now_ = ev->time;
     process_ = ev->process;
     event_map.erase(ev->process);
-    process_->run();
+    try {
+      process_->run();
+    } catch (std::exception &ex) {
+      Arrival* arrival = dynamic_cast<Arrival*>(process_);
+      throw Rcpp::exception(tfm::format(
+        "'%s'%s: %s",
+        process_->name,
+        arrival ? " in '" + arrival->get_activity()->name + "'" : "",
+        ex.what()).c_str(), false
+      );
+    }
     process_ = NULL;
     event_queue.erase(ev);
     return true;

--- a/inst/include/simmer/simulator_impl.h
+++ b/inst/include/simmer/simulator_impl.h
@@ -213,8 +213,8 @@ namespace simmer {
     } catch (std::exception &ex) {
       Arrival* arrival = dynamic_cast<Arrival*>(process_);
       throw Rcpp::exception(tfm::format(
-        "'%s'%s: %s",
-        process_->name,
+        "'%s' at %.2f%s:\n %s",
+        process_->name, now_,
         arrival ? " in '" + arrival->get_activity()->name + "'" : "",
         ex.what()).c_str(), false
       );


### PR DESCRIPTION
Provide more informative error messages. Before the patch:

```r
library(simmer)

t <- trajectory() %>%
  timeout(function() NULL)

simmer() %>%
  add_generator("dummy", t, at(pi)) %>%
  run()
#> Error in run_(private$sim_obj, until) :
#>  Expecting a single value: [extent=0].
```

After this patch, the error becomes

```r
#> Error: 'dummy0' at 3.14 in 'Timeout':
#>  Expecting a single value: [extent=0].
```

which specifies the arrival name, the current simulation time and the activity type in which the error arised.