### PR TITLE
Automatically initialise new attributes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * The C++ core has been refactorised into a header-only library under `inst/include` (#147 closing #145). Therefore, from now on it is possible to extend the C++ API from another package by listing `simmer` under the `LinkingTo` field in the DESCRIPTION file.
 * New generic `monitor` constructor enables the development of new monitoring backends in other packages (179f656, as part of #147).
 * New simulation-scoped logging levels. The `log_` activity has a new argument `level` which determines whether the message is printed depending on a global `log_level` defined in the `simmer` constructor (#152).
+* `set_attribute` and `set_global` gain a new argument to automatically initialise new attributes (#157). Useful to update counters and indexes in a single line, without initialisation boilerplate.
 
 ## Minor changes and fixes:
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -73,20 +73,20 @@ Select__new_func <- function(resources, policy, id) {
     .Call(`_simmer_Select__new_func`, resources, policy, id)
 }
 
-SetAttribute__new <- function(keys, values, global, mod) {
-    .Call(`_simmer_SetAttribute__new`, keys, values, global, mod)
+SetAttribute__new <- function(keys, values, global, mod, init) {
+    .Call(`_simmer_SetAttribute__new`, keys, values, global, mod, init)
 }
 
-SetAttribute__new_func1 <- function(keys, values, global, mod) {
-    .Call(`_simmer_SetAttribute__new_func1`, keys, values, global, mod)
+SetAttribute__new_func1 <- function(keys, values, global, mod, init) {
+    .Call(`_simmer_SetAttribute__new_func1`, keys, values, global, mod, init)
 }
 
-SetAttribute__new_func2 <- function(keys, values, global, mod) {
-    .Call(`_simmer_SetAttribute__new_func2`, keys, values, global, mod)
+SetAttribute__new_func2 <- function(keys, values, global, mod, init) {
+    .Call(`_simmer_SetAttribute__new_func2`, keys, values, global, mod, init)
 }
 
-SetAttribute__new_func3 <- function(keys, values, global, mod) {
-    .Call(`_simmer_SetAttribute__new_func3`, keys, values, global, mod)
+SetAttribute__new_func3 <- function(keys, values, global, mod, init) {
+    .Call(`_simmer_SetAttribute__new_func3`, keys, values, global, mod, init)
 }
 
 Activate__new <- function(source) {

--- a/R/trajectory-activities.R
+++ b/R/trajectory-activities.R
@@ -195,22 +195,24 @@ timeout_from_global <- function(.trj, key) timeout_from_attribute(.trj, key, TRU
 #' must return numeric value(s).
 #' @param global if \code{TRUE}, the attribute will be global instead of per-arrival.
 #' @param mod if set, \code{values} modify the attributes rather than substituting them.
+#' @param init initial value, applied if \code{mod} is set and the attribute was
+#' not previously initialised. Useful for counters or indexes.
 #'
 #' @return Returns the trajectory object.
 #' @seealso \code{\link{get_attribute}}.
 #' @export
-set_attribute <- function(.trj, keys, values, global=FALSE, mod=c(NA, "+", "*"))
+set_attribute <- function(.trj, keys, values, global=FALSE, mod=c(NA, "+", "*"), init=0)
   UseMethod("set_attribute")
 
 #' @export
-set_attribute.trajectory <- function(.trj, keys, values, global=FALSE, mod=c(NA, "+", "*"))
-  .trj$set_attribute(keys, values, global, mod=mod)
+set_attribute.trajectory <- function(.trj, keys, values, global=FALSE, mod=c(NA, "+", "*"), init=0)
+  .trj$set_attribute(keys, values, global, mod, init)
 
 #' @rdname set_attribute
 #' @details \code{set_global} is a shortcut for \code{set_attribute(global=TRUE)}.
 #' @export
-set_global <- function(.trj, keys, values, mod=c(NA, "+", "*"))
-  set_attribute(.trj, keys, values, TRUE, mod=mod)
+set_global <- function(.trj, keys, values, mod=c(NA, "+", "*"), init=0)
+  set_attribute(.trj, keys, values, TRUE, mod, init)
 
 #' Activate/Deactivate Sources
 #'

--- a/R/trajectory-class.R
+++ b/R/trajectory-class.R
@@ -181,19 +181,20 @@ Trajectory <- R6Class("trajectory",
       )
     },
 
-    set_attribute = function(keys, values, global=FALSE, mod=c(NA, "+", "*")) {
+    set_attribute = function(keys, values, global=FALSE, mod=c(NA, "+", "*"), init=0) {
       check_args(
         keys = c("string vector", "function"),
         values = c("numeric", "function"),
-        global = "flag"
+        global = "flag",
+        init = "numeric"
       )
       mod <- match.arg(mod)
       switch(
         binarise(is.function(keys), is.function(values)),
-        private$add_activity(SetAttribute__new(keys, values, global, mod)),
-        private$add_activity(SetAttribute__new_func1(keys, values, global, mod)),
-        private$add_activity(SetAttribute__new_func2(keys, values, global, mod)),
-        private$add_activity(SetAttribute__new_func3(keys, values, global, mod))
+        private$add_activity(SetAttribute__new(keys, values, global, mod, init)),
+        private$add_activity(SetAttribute__new_func1(keys, values, global, mod, init)),
+        private$add_activity(SetAttribute__new_func2(keys, values, global, mod, init)),
+        private$add_activity(SetAttribute__new_func3(keys, values, global, mod, init))
       )
     },
 

--- a/inst/include/simmer/activity.h
+++ b/inst/include/simmer/activity.h
@@ -21,7 +21,7 @@
 
 #include <simmer/common.h>
 
-#define MAX_PRINT_ARGS 4
+#define MAX_PRINT_ARGS 5
 #define ARG(arg) (#arg": "), arg
 
 namespace simmer {

--- a/inst/include/simmer/activity/arrival.h
+++ b/inst/include/simmer/activity/arrival.h
@@ -32,13 +32,13 @@ namespace simmer {
   public:
     CLONEABLE(SetAttribute<T COMMA U>)
 
-    SetAttribute(const T& keys, const U& values, bool global, char mod='N')
-      : Activity("SetAttribute"), keys(keys), values(values),
-        global(global), mod(mod), op(internal::get_op<double>(mod)) {}
+    SetAttribute(const T& keys, const U& values, bool global, char mod='N', double init=0)
+      : Activity("SetAttribute"), keys(keys), values(values), global(global),
+        mod(mod), op(internal::get_op<double>(mod)), init(init) {}
 
     void print(unsigned int indent = 0, bool verbose = false, bool brief = false) {
       Activity::print(indent, verbose, brief);
-      internal::print(brief, true, ARG(keys), ARG(values), ARG(global), ARG(mod));
+      internal::print(brief, true, ARG(keys), ARG(values), ARG(global), ARG(mod), ARG(init));
     }
 
     double run(Arrival* arrival) {
@@ -51,6 +51,7 @@ namespace simmer {
       if (op) {
         for (unsigned int i = 0; i < ks.size(); i++) {
           double attr = arrival->get_attribute(ks[i], global);
+          if (ISNA(attr)) attr = init;
           arrival->set_attribute(ks[i], op(attr, vals[i]), global);
         }
       } else for (unsigned int i = 0; i < ks.size(); i++)
@@ -65,6 +66,7 @@ namespace simmer {
     bool global;
     char mod;
     Fn<double(double, double)> op;
+    double init;
   };
 
   /**

--- a/inst/include/simmer/activity/arrival.h
+++ b/inst/include/simmer/activity/arrival.h
@@ -48,12 +48,10 @@ namespace simmer {
       if (ks.size() != vals.size())
         Rcpp::stop("number of keys and values don't match");
 
-      if (op) {
-        for (unsigned int i = 0; i < ks.size(); i++) {
-          double attr = arrival->get_attribute(ks[i], global);
-          if (ISNA(attr)) attr = init;
-          arrival->set_attribute(ks[i], op(attr, vals[i]), global);
-        }
+      if (op) for (unsigned int i = 0; i < ks.size(); i++) {
+        double attr = arrival->get_attribute(ks[i], global);
+        if (ISNA(attr)) attr = init;
+        arrival->set_attribute(ks[i], op(attr, vals[i]), global);
       } else for (unsigned int i = 0; i < ks.size(); i++)
         arrival->set_attribute(ks[i], vals[i], global);
 

--- a/man/set_attribute.Rd
+++ b/man/set_attribute.Rd
@@ -5,9 +5,10 @@
 \alias{set_global}
 \title{Set Attributes}
 \usage{
-set_attribute(.trj, keys, values, global = FALSE, mod = c(NA, "+", "*"))
+set_attribute(.trj, keys, values, global = FALSE, mod = c(NA, "+", "*"),
+  init = 0)
 
-set_global(.trj, keys, values, mod = c(NA, "+", "*"))
+set_global(.trj, keys, values, mod = c(NA, "+", "*"), init = 0)
 }
 \arguments{
 \item{.trj}{the trajectory object.}
@@ -21,6 +22,9 @@ must return numeric value(s).}
 \item{global}{if \code{TRUE}, the attribute will be global instead of per-arrival.}
 
 \item{mod}{if set, \code{values} modify the attributes rather than substituting them.}
+
+\item{init}{initial value, applied if \code{mod} is set and the attribute was
+not previously initialised. Useful for counters or indexes.}
 }
 \value{
 Returns the trajectory object.

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -245,8 +245,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // SetAttribute__new
-SEXP SetAttribute__new(const std::vector<std::string>& keys, const std::vector<double>& values, bool global, char mod);
-RcppExport SEXP _simmer_SetAttribute__new(SEXP keysSEXP, SEXP valuesSEXP, SEXP globalSEXP, SEXP modSEXP) {
+SEXP SetAttribute__new(const std::vector<std::string>& keys, const std::vector<double>& values, bool global, char mod, double init);
+RcppExport SEXP _simmer_SetAttribute__new(SEXP keysSEXP, SEXP valuesSEXP, SEXP globalSEXP, SEXP modSEXP, SEXP initSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -254,13 +254,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const std::vector<double>& >::type values(valuesSEXP);
     Rcpp::traits::input_parameter< bool >::type global(globalSEXP);
     Rcpp::traits::input_parameter< char >::type mod(modSEXP);
-    rcpp_result_gen = Rcpp::wrap(SetAttribute__new(keys, values, global, mod));
+    Rcpp::traits::input_parameter< double >::type init(initSEXP);
+    rcpp_result_gen = Rcpp::wrap(SetAttribute__new(keys, values, global, mod, init));
     return rcpp_result_gen;
 END_RCPP
 }
 // SetAttribute__new_func1
-SEXP SetAttribute__new_func1(const Function& keys, const std::vector<double>& values, bool global, char mod);
-RcppExport SEXP _simmer_SetAttribute__new_func1(SEXP keysSEXP, SEXP valuesSEXP, SEXP globalSEXP, SEXP modSEXP) {
+SEXP SetAttribute__new_func1(const Function& keys, const std::vector<double>& values, bool global, char mod, double init);
+RcppExport SEXP _simmer_SetAttribute__new_func1(SEXP keysSEXP, SEXP valuesSEXP, SEXP globalSEXP, SEXP modSEXP, SEXP initSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -268,13 +269,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const std::vector<double>& >::type values(valuesSEXP);
     Rcpp::traits::input_parameter< bool >::type global(globalSEXP);
     Rcpp::traits::input_parameter< char >::type mod(modSEXP);
-    rcpp_result_gen = Rcpp::wrap(SetAttribute__new_func1(keys, values, global, mod));
+    Rcpp::traits::input_parameter< double >::type init(initSEXP);
+    rcpp_result_gen = Rcpp::wrap(SetAttribute__new_func1(keys, values, global, mod, init));
     return rcpp_result_gen;
 END_RCPP
 }
 // SetAttribute__new_func2
-SEXP SetAttribute__new_func2(const std::vector<std::string>& keys, const Function& values, bool global, char mod);
-RcppExport SEXP _simmer_SetAttribute__new_func2(SEXP keysSEXP, SEXP valuesSEXP, SEXP globalSEXP, SEXP modSEXP) {
+SEXP SetAttribute__new_func2(const std::vector<std::string>& keys, const Function& values, bool global, char mod, double init);
+RcppExport SEXP _simmer_SetAttribute__new_func2(SEXP keysSEXP, SEXP valuesSEXP, SEXP globalSEXP, SEXP modSEXP, SEXP initSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -282,13 +284,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const Function& >::type values(valuesSEXP);
     Rcpp::traits::input_parameter< bool >::type global(globalSEXP);
     Rcpp::traits::input_parameter< char >::type mod(modSEXP);
-    rcpp_result_gen = Rcpp::wrap(SetAttribute__new_func2(keys, values, global, mod));
+    Rcpp::traits::input_parameter< double >::type init(initSEXP);
+    rcpp_result_gen = Rcpp::wrap(SetAttribute__new_func2(keys, values, global, mod, init));
     return rcpp_result_gen;
 END_RCPP
 }
 // SetAttribute__new_func3
-SEXP SetAttribute__new_func3(const Function& keys, const Function& values, bool global, char mod);
-RcppExport SEXP _simmer_SetAttribute__new_func3(SEXP keysSEXP, SEXP valuesSEXP, SEXP globalSEXP, SEXP modSEXP) {
+SEXP SetAttribute__new_func3(const Function& keys, const Function& values, bool global, char mod, double init);
+RcppExport SEXP _simmer_SetAttribute__new_func3(SEXP keysSEXP, SEXP valuesSEXP, SEXP globalSEXP, SEXP modSEXP, SEXP initSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -296,7 +299,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const Function& >::type values(valuesSEXP);
     Rcpp::traits::input_parameter< bool >::type global(globalSEXP);
     Rcpp::traits::input_parameter< char >::type mod(modSEXP);
-    rcpp_result_gen = Rcpp::wrap(SetAttribute__new_func3(keys, values, global, mod));
+    Rcpp::traits::input_parameter< double >::type init(initSEXP);
+    rcpp_result_gen = Rcpp::wrap(SetAttribute__new_func3(keys, values, global, mod, init));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1267,10 +1271,10 @@ static const R_CallMethodDef CallEntries[] = {
     {"_simmer_SetQueueSelected__new_func", (DL_FUNC) &_simmer_SetQueueSelected__new_func, 3},
     {"_simmer_Select__new", (DL_FUNC) &_simmer_Select__new, 3},
     {"_simmer_Select__new_func", (DL_FUNC) &_simmer_Select__new_func, 3},
-    {"_simmer_SetAttribute__new", (DL_FUNC) &_simmer_SetAttribute__new, 4},
-    {"_simmer_SetAttribute__new_func1", (DL_FUNC) &_simmer_SetAttribute__new_func1, 4},
-    {"_simmer_SetAttribute__new_func2", (DL_FUNC) &_simmer_SetAttribute__new_func2, 4},
-    {"_simmer_SetAttribute__new_func3", (DL_FUNC) &_simmer_SetAttribute__new_func3, 4},
+    {"_simmer_SetAttribute__new", (DL_FUNC) &_simmer_SetAttribute__new, 5},
+    {"_simmer_SetAttribute__new_func1", (DL_FUNC) &_simmer_SetAttribute__new_func1, 5},
+    {"_simmer_SetAttribute__new_func2", (DL_FUNC) &_simmer_SetAttribute__new_func2, 5},
+    {"_simmer_SetAttribute__new_func3", (DL_FUNC) &_simmer_SetAttribute__new_func3, 5},
     {"_simmer_Activate__new", (DL_FUNC) &_simmer_Activate__new, 1},
     {"_simmer_Activate__new_func", (DL_FUNC) &_simmer_Activate__new_func, 1},
     {"_simmer_Deactivate__new", (DL_FUNC) &_simmer_Deactivate__new, 1},

--- a/src/activity.cpp
+++ b/src/activity.cpp
@@ -121,35 +121,35 @@ SEXP Select__new_func(const Function& resources, const std::string& policy, int 
 }
 
 //[[Rcpp::export]]
-SEXP SetAttribute__new(const std::vector<std::string>& keys,
-                       const std::vector<double>& values, bool global, char mod)
+SEXP SetAttribute__new(const std::vector<std::string>& keys, const std::vector<double>& values,
+                       bool global, char mod, double init)
 {
   return XPtr<SetAttribute<VEC<std::string>, VEC<double> > >(
-      new SetAttribute<VEC<std::string>, VEC<double> >(keys, values, global, mod));
+      new SetAttribute<VEC<std::string>, VEC<double> >(keys, values, global, mod, init));
 }
 
 //[[Rcpp::export]]
-SEXP SetAttribute__new_func1(const Function& keys,
-                             const std::vector<double>& values, bool global, char mod)
+SEXP SetAttribute__new_func1(const Function& keys, const std::vector<double>& values,
+                             bool global, char mod, double init)
 {
   return XPtr<SetAttribute<Function, VEC<double> > >(
-      new SetAttribute<Function, VEC<double> >(keys, values, global, mod));
+      new SetAttribute<Function, VEC<double> >(keys, values, global, mod, init));
 }
 
 //[[Rcpp::export]]
-SEXP SetAttribute__new_func2(const std::vector<std::string>& keys,
-                             const Function& values, bool global, char mod)
+SEXP SetAttribute__new_func2(const std::vector<std::string>& keys, const Function& values,
+                             bool global, char mod, double init)
 {
   return XPtr<SetAttribute<VEC<std::string>, Function> >(
-      new SetAttribute<VEC<std::string>, Function>(keys, values, global, mod));
+      new SetAttribute<VEC<std::string>, Function>(keys, values, global, mod, init));
 }
 
 //[[Rcpp::export]]
-SEXP SetAttribute__new_func3(const Function& keys,
-                             const Function& values, bool global, char mod)
+SEXP SetAttribute__new_func3(const Function& keys, const Function& values,
+                             bool global, char mod, double init)
 {
   return XPtr<SetAttribute<Function, Function> >(
-      new SetAttribute<Function, Function>(keys, values, global, mod));
+      new SetAttribute<Function, Function>(keys, values, global, mod, init));
 }
 
 //[[Rcpp::export]]

--- a/tests/testthat/test-trajectory-setattribute.R
+++ b/tests/testthat/test-trajectory-setattribute.R
@@ -119,3 +119,16 @@ test_that("arrival attributes are returned empty when mon level is < 2", {
   expect_equal(attributes[1, ]$key, "test")
   expect_equal(attributes[1, ]$value, 456)
 })
+
+test_that("attributes are automatically initialised with modifiers", {
+  t <- trajectory() %>%
+    set_attribute("asdf", 1, mod="+") %>%
+    set_global("fdsa", 2, mod="+", init=3)
+
+  attr <- simmer() %>%
+    add_generator("dummy", t, at(0), mon=2) %>%
+    run() %>%
+    get_mon_attributes()
+
+  expect_equal(attr$value, c(1, 5))
+})


### PR DESCRIPTION
E.g., 

```r
library(simmer)

t <- trajectory() %>%
  set_attribute("asdf", 1, mod="+", init=10) %>%
  set_global("fdsa", 2, mod="+") # init=0 by default

simmer() %>%
  add_generator("dummy", t, at(0), mon=2) %>%
  run() %>%
  get_mon_attributes()
#>   time   name  key value replication
#> 1    0 dummy0 asdf    11           1
#> 2    0        fdsa     2           1
```