### PR TITLE
`documentclass: jss` will be required in the next version of rticles

### DIFF
--- a/vignettes/simmer-02-jss.Rmd
+++ b/vignettes/simmer-02-jss.Rmd
@@ -40,6 +40,7 @@ preamble: >
   \usepackage{subfig}
 output: if (packageVersion("rticles") < 0.5 || rmarkdown::pandoc_version() >= 2)
   rticles::jss_article else rmarkdown::html_vignette
+documentclass: jss
 classoption: nojss
 citation_package: natbib
 bibliography: jss.bib


### PR DESCRIPTION
Without this, you will run into an error in `R CMD check`:

```
! Undefined control sequence.
 l.15 \Plainauthor
                  {Iñaki Ucar, Bart Smeets, Arturo Azcorra} 
 
 Error: processing vignette 'simmer-02-jss.Rmd' failed with diagnostics:
 Failed to compile simmer-02-jss.tex.
```

Thanks!