### PR TITLE
fix activity storage issues

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,17 @@
+# simmer 4.4.2
+
+## Minor changes and fixes
+
+- Fix memory issues in `trap()`, `synchronize()` and `rollback()`. These are
+  stateful activities that require storing information about passing arrivals to
+  manage clones or redirections. These activities were not properly cleaning
+  their storage when arrivals were rejected at some point in the trajectory. As
+  a result, certain simulations with these activities involved may show random
+  improper behaviour depending on how memory reuse happens. This patch unifies
+  storage management for stateful activities, adds a new interface to register
+  these activities and another interface for arrivals to notify their
+  termination, so that the stored information is properly cleaned up (#231).
+
 # simmer 4.4.1
 
 ## Minor changes and fixes

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,6 +1,6 @@
 ## Patch release
 
-Bug fixes + improved documentation.
+Fix random issues due to dangling pointers under memory reuse.
 
 Regarding the package title, Uwe asked us in a past submission to remove
 "for R" because it is redundant. If it is not an issue, we would like to keep
@@ -13,7 +13,7 @@ written in Julia".
 ## Test environments
 
 - Fedora 31 + GCC + clang (local), R 3.6.3
-- Ubuntu 16.04 + GCC (on Travis-CI), R 3.5.3, 3.6.3, devel
+- Ubuntu 16.04 + GCC (on Travis-CI), R 3.6.3, 4.0.0, devel
 - linux-x86_64-rocker-gcc-san (on r-hub)
 - ubuntu-rchk (on r-hub)
 - win-builder, R devel

--- a/inst/include/simmer.h
+++ b/inst/include/simmer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2019 Iñaki Ucar
+// Copyright (C) 2018-2020 Iñaki Ucar
 //
 // This file is part of simmer.
 //
@@ -27,6 +27,7 @@
 
 #include <simmer/activity.h>
 #include <simmer/activity/fork.h>
+#include <simmer/activity/storage.h>
 #include <simmer/activity/debug.h>
 #include <simmer/activity/timeout.h>
 #include <simmer/activity/arrival.h>

--- a/inst/include/simmer/activity.h
+++ b/inst/include/simmer/activity.h
@@ -1,5 +1,5 @@
 // Copyright (C) 2015-2016 Bart Smeets and Iñaki Ucar
-// Copyright (C) 2016-2018 Iñaki Ucar
+// Copyright (C) 2016-2018,2020 Iñaki Ucar
 //
 // This file is part of simmer.
 //
@@ -84,6 +84,11 @@ namespace simmer {
      */
     virtual Activity* get_prev() { return prev; }
     virtual void set_prev(Activity* activity) { prev = activity; }
+
+    /**
+     * Remove any stored information
+     */
+    virtual void remove(Arrival* arrival) {}
 
   protected:
     Activity* next;

--- a/inst/include/simmer/activity/fork.h
+++ b/inst/include/simmer/activity/fork.h
@@ -27,7 +27,7 @@ namespace simmer {
   class Fork : public virtual Activity {
   public:
     Fork(const VEC<bool>& cont, const VEC<REnv>& trj)
-      : cont(cont), trj(trj), path(-1)
+      : Activity("Fork"), cont(cont), trj(trj), path(-1)
     {
       foreach_ (const VEC<REnv>::value_type& itr, trj) {
         Activity* head = internal::head(itr);
@@ -38,7 +38,7 @@ namespace simmer {
       }
     }
 
-    Fork(const Fork& o) : cont(o.cont), trj(o.trj), path(-1) {
+    Fork(const Fork& o) : Activity(o), cont(o.cont), trj(o.trj), path(-1) {
       heads.clear();
       tails.clear();
       foreach_ (VEC<REnv>::value_type& itr, trj) {

--- a/inst/include/simmer/activity/fork.h
+++ b/inst/include/simmer/activity/fork.h
@@ -1,5 +1,5 @@
 // Copyright (C) 2015-2016 Bart Smeets and Iñaki Ucar
-// Copyright (C) 2016-2018 Iñaki Ucar
+// Copyright (C) 2016-2018,2020 Iñaki Ucar
 //
 // This file is part of simmer.
 //
@@ -24,11 +24,10 @@
 namespace simmer {
 
   // abstract class for multipath activities
-  class Fork : public Activity {
+  class Fork : public virtual Activity {
   public:
-    Fork(const std::string& name, const VEC<bool>& cont,
-         const VEC<REnv>& trj, int priority = 0)
-      : Activity(name, priority), cont(cont), trj(trj), path(-1)
+    Fork(const VEC<bool>& cont, const VEC<REnv>& trj)
+      : cont(cont), trj(trj), path(-1)
     {
       foreach_ (const VEC<REnv>::value_type& itr, trj) {
         Activity* head = internal::head(itr);
@@ -39,7 +38,7 @@ namespace simmer {
       }
     }
 
-    Fork(const Fork& o) : Activity(o), cont(o.cont), trj(o.trj), path(-1) {
+    Fork(const Fork& o) : cont(o.cont), trj(o.trj), path(-1) {
       heads.clear();
       tails.clear();
       foreach_ (VEC<REnv>::value_type& itr, trj) {

--- a/inst/include/simmer/activity/renege.h
+++ b/inst/include/simmer/activity/renege.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2019 Iñaki Ucar
+// Copyright (C) 2016-2020 Iñaki Ucar
 //
 // This file is part of simmer.
 //
@@ -31,7 +31,7 @@ namespace simmer {
     CLONEABLE(Leave<T>)
 
     Leave(const T& prob, const VEC<REnv>& trj, bool keep_seized)
-      : Fork("Leave", VEC<bool>(trj.size(), false), trj), prob(prob),
+      : Activity("Leave"), Fork(VEC<bool>(trj.size(), false), trj), prob(prob),
         keep_seized(keep_seized) {}
 
     void print(unsigned int indent = 0, bool verbose = false, bool brief = false) {
@@ -66,7 +66,7 @@ namespace simmer {
     CLONEABLE(RenegeIn<T>)
 
     RenegeIn(const T& t, const VEC<REnv>& trj, bool keep_seized)
-      : Fork("RenegeIn", VEC<bool>(trj.size(), false), trj), t(t),
+      : Activity("RenegeIn"), Fork(VEC<bool>(trj.size(), false), trj), t(t),
         keep_seized(keep_seized) {}
 
     void print(unsigned int indent = 0, bool verbose = false, bool brief = false) {
@@ -97,7 +97,7 @@ namespace simmer {
     CLONEABLE(RenegeIf<T>)
 
     RenegeIf(const T& signal, const VEC<REnv>& trj, bool keep_seized)
-      : Fork("RenegeIf", VEC<bool>(trj.size(), false), trj), signal(signal),
+      : Activity("RenegeIf"), Fork(VEC<bool>(trj.size(), false), trj), signal(signal),
         keep_seized(keep_seized) {}
 
     void print(unsigned int indent = 0, bool verbose = false, bool brief = false) {
@@ -147,7 +147,7 @@ namespace simmer {
     CLONEABLE(HandleUnfinished)
 
     HandleUnfinished(const VEC<REnv>& trj)
-      : Fork("HandleUnfinished", VEC<bool>(trj.size(), false), trj) {}
+      : Activity("HandleUnfinished"), Fork(VEC<bool>(trj.size(), false), trj) {}
 
     void print(unsigned int indent = 0, bool verbose = false, bool brief = false) {
       Activity::print(indent, verbose, brief);

--- a/inst/include/simmer/activity/resource.h
+++ b/inst/include/simmer/activity/resource.h
@@ -1,5 +1,5 @@
 // Copyright (C) 2015-2016 Bart Smeets and Iñaki Ucar
-// Copyright (C) 2016-2018 Iñaki Ucar
+// Copyright (C) 2016-2018,2020 Iñaki Ucar
 //
 // This file is part of simmer.
 //
@@ -35,12 +35,12 @@ namespace simmer {
 
     Seize(const std::string& resource, const T& amount, const VEC<bool>& cont,
           const VEC<REnv>& trj, unsigned short mask)
-      : Fork("Seize", cont, trj),
+      : Activity("Seize"), Fork(cont, trj),
         internal::ResGetter("Seize", resource), amount(amount), mask(mask) {}
 
     Seize(int id, const T& amount, const VEC<bool>& cont,
           const VEC<REnv>& trj, unsigned short mask)
-      : Fork("Seize", cont, trj),
+      : Activity("Seize"), Fork(cont, trj),
         internal::ResGetter("Seize", id), amount(amount), mask(mask) {}
 
     void print(unsigned int indent = 0, bool verbose = false, bool brief = false) {

--- a/inst/include/simmer/activity/storage.h
+++ b/inst/include/simmer/activity/storage.h
@@ -44,7 +44,7 @@ namespace simmer {
   template <typename U, typename V>
   class Storage : public virtual Activity {
   public:
-    Storage() {}
+    Storage() : Activity("Storage") {}
 
     void remove(Arrival* arrival) {
       typename UMAP<U, V>::iterator search =

--- a/inst/include/simmer/activity/storage.h
+++ b/inst/include/simmer/activity/storage.h
@@ -1,0 +1,77 @@
+// Copyright (C) 2020 Iñaki Ucar
+//
+// This file is part of simmer.
+//
+// simmer is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// simmer is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with simmer. If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef simmer__activity_storage_h
+#define simmer__activity_storage_h
+
+#include <simmer/activity.h>
+#include <simmer/process/arrival.h>
+
+namespace simmer {
+
+  namespace internal {
+
+    template <typename U>
+    U storage_key(Arrival* arrival);
+
+    template <>
+    inline Arrival* storage_key<Arrival*>(Arrival* arrival) {
+      return arrival;
+    }
+
+    template <>
+    inline std::string storage_key<std::string>(Arrival* arrival) {
+      return arrival->name;
+    }
+
+  } // namespace internal
+
+  // abstract class for activities with state
+  template <typename U, typename V>
+  class Storage : public virtual Activity {
+  public:
+    Storage() {}
+
+    void remove(Arrival* arrival) {
+      typename UMAP<U, V>::iterator search =
+        storage.find(internal::storage_key<U>(arrival));
+      if (search == storage.end())
+        Rcpp::stop("illegal removal of arrival '%s'", arrival->name); // # nocov
+      storage.erase(search);
+      arrival->unregister_entity(this, boost::is_same<U, std::string>::value);
+    }
+
+  protected:
+    bool storage_find(Arrival* arrival) {
+      if (storage.find(internal::storage_key<U>(arrival)) == storage.end())
+        return false;
+      return true;
+    }
+
+    V& storage_get(Arrival* arrival) {
+      if (!storage_find(arrival))
+        arrival->register_entity(this, boost::is_same<U, std::string>::value);
+      return storage[internal::storage_key<U>(arrival)];
+    }
+
+  private:
+    UMAP<U, V> storage;
+  };
+
+} // namespace simmer
+
+#endif

--- a/src/activity.cpp
+++ b/src/activity.cpp
@@ -1,6 +1,6 @@
 // Copyright (C) 2014 Bart Smeets
 // Copyright (C) 2015 Iñaki Ucar and Bart Smeets
-// Copyright (C) 2015-2019 Iñaki Ucar
+// Copyright (C) 2015-2020 Iñaki Ucar
 //
 // This file is part of simmer.
 //
@@ -26,120 +26,120 @@ using namespace simmer;
 SEXP Seize__new(const std::string& resource, int amount, std::vector<bool> cont,
                 const std::vector<Environment>& trj, unsigned short mask)
 {
-  return XPtr<Seize<int> >(new Seize<int>(resource, amount, cont, trj, mask));
+  return XPtr<Activity>(new Seize<int>(resource, amount, cont, trj, mask));
 }
 
 //[[Rcpp::export]]
 SEXP Seize__new_func(const std::string& resource, const Function& amount, std::vector<bool> cont,
                      const std::vector<Environment>& trj, unsigned short mask)
 {
-  return XPtr<Seize<Function> >(new Seize<Function>(resource, amount, cont, trj, mask));
+  return XPtr<Activity>(new Seize<Function>(resource, amount, cont, trj, mask));
 }
 
 //[[Rcpp::export]]
 SEXP SeizeSelected__new(int id, int amount, std::vector<bool> cont,
                         const std::vector<Environment>& trj, unsigned short mask)
 {
-  return XPtr<Seize<int> >(new Seize<int>(id, amount, cont, trj, mask));
+  return XPtr<Activity>(new Seize<int>(id, amount, cont, trj, mask));
 }
 
 //[[Rcpp::export]]
 SEXP SeizeSelected__new_func(int id, const Function& amount, std::vector<bool> cont,
                              const std::vector<Environment>& trj, unsigned short mask)
 {
-  return XPtr<Seize<Function> >(new Seize<Function>(id, amount, cont, trj, mask));
+  return XPtr<Activity>(new Seize<Function>(id, amount, cont, trj, mask));
 }
 
 //[[Rcpp::export]]
 SEXP Release__new(const std::string& resource, int amount) {
-  return XPtr<Release<int> >(new Release<int>(resource, amount));
+  return XPtr<Activity>(new Release<int>(resource, amount));
 }
 
 //[[Rcpp::export]]
 SEXP Release__new_func(const std::string& resource, const Function& amount) {
-  return XPtr<Release<Function> >(new Release<Function>(resource, amount));
+  return XPtr<Activity>(new Release<Function>(resource, amount));
 }
 
 //[[Rcpp::export]]
 SEXP ReleaseAll__new(const std::string& resource) {
-  return XPtr<Release<int> >(new Release<int>(resource));
+  return XPtr<Activity>(new Release<int>(resource));
 }
 
 //[[Rcpp::export]]
 SEXP ReleaseAll__new_void() {
-  return XPtr<Release<int> >(new Release<int>());
+  return XPtr<Activity>(new Release<int>());
 }
 
 //[[Rcpp::export]]
 SEXP ReleaseSelected__new(int id, int amount) {
-  return XPtr<Release<int> >(new Release<int>(id, amount));
+  return XPtr<Activity>(new Release<int>(id, amount));
 }
 
 //[[Rcpp::export]]
 SEXP ReleaseSelected__new_func(int id, const Function& amount) {
-  return XPtr<Release<Function> >(new Release<Function>(id, amount));
+  return XPtr<Activity>(new Release<Function>(id, amount));
 }
 
 //[[Rcpp::export]]
 SEXP ReleaseSelectedAll__new(int id) {
-  return XPtr<Release<int> >(new Release<int>(id));
+  return XPtr<Activity>(new Release<int>(id));
 }
 
 //[[Rcpp::export]]
 SEXP SetCapacity__new(const std::string& resource, double value, char mod) {
-  return XPtr<SetCapacity<double> >(new SetCapacity<double>(resource, value, mod));
+  return XPtr<Activity>(new SetCapacity<double>(resource, value, mod));
 }
 
 //[[Rcpp::export]]
 SEXP SetCapacity__new_func(const std::string& resource, const Function& value, char mod) {
-  return XPtr<SetCapacity<Function> >(new SetCapacity<Function>(resource, value, mod));
+  return XPtr<Activity>(new SetCapacity<Function>(resource, value, mod));
 }
 
 //[[Rcpp::export]]
 SEXP SetCapacitySelected__new(int id, double value, char mod) {
-  return XPtr<SetCapacity<double> >(new SetCapacity<double>(id, value, mod));
+  return XPtr<Activity>(new SetCapacity<double>(id, value, mod));
 }
 
 //[[Rcpp::export]]
 SEXP SetCapacitySelected__new_func(int id, const Function& value, char mod) {
-  return XPtr<SetCapacity<Function> >(new SetCapacity<Function>(id, value, mod));
+  return XPtr<Activity>(new SetCapacity<Function>(id, value, mod));
 }
 
 //[[Rcpp::export]]
 SEXP SetQueue__new(const std::string& resource, double value, char mod) {
-  return XPtr<SetQueue<double> >(new SetQueue<double>(resource, value, mod));
+  return XPtr<Activity>(new SetQueue<double>(resource, value, mod));
 }
 
 //[[Rcpp::export]]
 SEXP SetQueue__new_func(const std::string& resource, const Function& value, char mod) {
-  return XPtr<SetQueue<Function> >(new SetQueue<Function>(resource, value, mod));
+  return XPtr<Activity>(new SetQueue<Function>(resource, value, mod));
 }
 
 //[[Rcpp::export]]
 SEXP SetQueueSelected__new(int id, double value, char mod) {
-  return XPtr<SetQueue<double> >(new SetQueue<double>(id, value, mod));
+  return XPtr<Activity>(new SetQueue<double>(id, value, mod));
 }
 
 //[[Rcpp::export]]
 SEXP SetQueueSelected__new_func(int id, const Function& value, char mod) {
-  return XPtr<SetQueue<Function> >(new SetQueue<Function>(id, value, mod));
+  return XPtr<Activity>(new SetQueue<Function>(id, value, mod));
 }
 
 //[[Rcpp::export]]
 SEXP Select__new(const std::vector<std::string>& resources, const std::string& policy, int id) {
-  return XPtr<Select<VEC<std::string> > >(new Select<VEC<std::string> >(resources, policy, id));
+  return XPtr<Activity>(new Select<VEC<std::string> >(resources, policy, id));
 }
 
 //[[Rcpp::export]]
 SEXP Select__new_func(const Function& resources, const std::string& policy, int id) {
-  return XPtr<Select<Function> >(new Select<Function>(resources, policy, id));
+  return XPtr<Activity>(new Select<Function>(resources, policy, id));
 }
 
 //[[Rcpp::export]]
 SEXP SetAttribute__new(const std::vector<std::string>& keys, const std::vector<double>& values,
                        bool global, char mod, double init)
 {
-  return XPtr<SetAttribute<VEC<std::string>, VEC<double> > >(
+  return XPtr<Activity>(
       new SetAttribute<VEC<std::string>, VEC<double> >(keys, values, global, mod, init));
 }
 
@@ -147,7 +147,7 @@ SEXP SetAttribute__new(const std::vector<std::string>& keys, const std::vector<d
 SEXP SetAttribute__new_func1(const Function& keys, const std::vector<double>& values,
                              bool global, char mod, double init)
 {
-  return XPtr<SetAttribute<Function, VEC<double> > >(
+  return XPtr<Activity>(
       new SetAttribute<Function, VEC<double> >(keys, values, global, mod, init));
 }
 
@@ -155,7 +155,7 @@ SEXP SetAttribute__new_func1(const Function& keys, const std::vector<double>& va
 SEXP SetAttribute__new_func2(const std::vector<std::string>& keys, const Function& values,
                              bool global, char mod, double init)
 {
-  return XPtr<SetAttribute<VEC<std::string>, Function> >(
+  return XPtr<Activity>(
       new SetAttribute<VEC<std::string>, Function>(keys, values, global, mod, init));
 }
 
@@ -163,259 +163,249 @@ SEXP SetAttribute__new_func2(const std::vector<std::string>& keys, const Functio
 SEXP SetAttribute__new_func3(const Function& keys, const Function& values,
                              bool global, char mod, double init)
 {
-  return XPtr<SetAttribute<Function, Function> >(
+  return XPtr<Activity>(
       new SetAttribute<Function, Function>(keys, values, global, mod, init));
 }
 
 //[[Rcpp::export]]
 SEXP Activate__new(const std::vector<std::string>& sources) {
-  return XPtr<Activate<VEC<std::string> > >(
-      new Activate<VEC<std::string> >(sources));
+  return XPtr<Activity>(new Activate<VEC<std::string> >(sources));
 }
 
 //[[Rcpp::export]]
 SEXP Activate__new_func(const Function& sources) {
-  return XPtr<Activate<Function> >(new Activate<Function>(sources));
+  return XPtr<Activity>(new Activate<Function>(sources));
 }
 
 //[[Rcpp::export]]
 SEXP Deactivate__new(const std::vector<std::string>& sources) {
-  return XPtr<Deactivate<VEC<std::string> > >(
-      new Deactivate<VEC<std::string> >(sources));
+  return XPtr<Activity>(new Deactivate<VEC<std::string> >(sources));
 }
 
 //[[Rcpp::export]]
 SEXP Deactivate__new_func(const Function& sources) {
-  return XPtr<Deactivate<Function> >(new Deactivate<Function>(sources));
+  return XPtr<Activity>(new Deactivate<Function>(sources));
 }
 
 //[[Rcpp::export]]
 SEXP SetTraj__new(const std::vector<std::string>& sources, const Environment& trj) {
-  return XPtr<SetTraj<VEC<std::string> > >(
-      new SetTraj<VEC<std::string> >(sources, trj));
+  return XPtr<Activity>(new SetTraj<VEC<std::string> >(sources, trj));
 }
 
 //[[Rcpp::export]]
 SEXP SetTraj__new_func(const Function& sources, const Environment& trj) {
-  return XPtr<SetTraj<Function> >(new SetTraj<Function>(sources, trj));
+  return XPtr<Activity>(new SetTraj<Function>(sources, trj));
 }
 
 //[[Rcpp::export]]
 SEXP SetSourceFn__new(const std::vector<std::string>& sources, const Function& dist) {
-  return XPtr<SetSource<VEC<std::string>, Function> >(
-      new SetSource<VEC<std::string>, Function>(sources, dist));
+  return XPtr<Activity>(new SetSource<VEC<std::string>, Function>(sources, dist));
 }
 
 //[[Rcpp::export]]
 SEXP SetSourceFn__new_func(const Function& sources, const Function& dist) {
-  return XPtr<SetSource<Function, Function> >(
-      new SetSource<Function, Function>(sources, dist));
+  return XPtr<Activity>(new SetSource<Function, Function>(sources, dist));
 }
 
 //[[Rcpp::export]]
 SEXP SetSourceDF__new(const std::vector<std::string>& sources, const DataFrame& data) {
-  return XPtr<SetSource<VEC<std::string>, DataFrame> >(
-      new SetSource<VEC<std::string>, DataFrame>(sources, data));
+  return XPtr<Activity>(new SetSource<VEC<std::string>, DataFrame>(sources, data));
 }
 
 //[[Rcpp::export]]
 SEXP SetSourceDF__new_func(const Function& sources, const DataFrame& data) {
-  return XPtr<SetSource<Function, DataFrame> >(
-      new SetSource<Function, DataFrame>(sources, data));
+  return XPtr<Activity>(new SetSource<Function, DataFrame>(sources, data));
 }
 
 //[[Rcpp::export]]
 SEXP SetPrior__new(const std::vector<int>& values, char mod) {
-  return XPtr<SetPrior<VEC<int> > >(new SetPrior<VEC<int> >(values, mod));
+  return XPtr<Activity>(new SetPrior<VEC<int> >(values, mod));
 }
 
 //[[Rcpp::export]]
 SEXP SetPrior__new_func(const Function& values, char mod) {
-  return XPtr<SetPrior<Function> >(new SetPrior<Function>(values, mod));
+  return XPtr<Activity>(new SetPrior<Function>(values, mod));
 }
 
 //[[Rcpp::export]]
 SEXP Timeout__new(double delay) {
-  return XPtr<Timeout<double> >(new Timeout<double>(delay));
+  return XPtr<Activity>(new Timeout<double>(delay));
 }
 
 //[[Rcpp::export]]
 SEXP Timeout__new_func(const Function& task) {
-  return XPtr<Timeout<Function> >(new Timeout<Function>(task));
+  return XPtr<Activity>(new Timeout<Function>(task));
 }
 
 //[[Rcpp::export]]
 SEXP Timeout__new_attr(const std::string& key, bool global) {
   typedef FnWrap<double, Arrival*, std::string> Callback;
   Callback call = Callback(BIND(&Arrival::get_attribute, _1, key, global), key);
-  return XPtr<Timeout<Callback> >(new Timeout<Callback>(call));
+  return XPtr<Activity>(new Timeout<Callback>(call));
 }
 
 //[[Rcpp::export]]
 SEXP Branch__new(const Function& option, std::vector<bool> cont,
                  const std::vector<Environment>& trj)
 {
-  return XPtr<Branch>(new Branch(option, cont, trj));
+  return XPtr<Activity>(new Branch(option, cont, trj));
 }
 
 //[[Rcpp::export]]
 SEXP Rollback__new(int amount, int times) {
-  return XPtr<Rollback>(new Rollback(amount, times));
+  return XPtr<Activity>(new Rollback(amount, times));
 }
 
 //[[Rcpp::export]]
 SEXP Rollback__new_func(int amount, const Function& check) {
-  return XPtr<Rollback>(new Rollback(amount, 0, check));
+  return XPtr<Activity>(new Rollback(amount, 0, check));
 }
 
 //[[Rcpp::export]]
 SEXP Leave__new(double prob, const std::vector<Environment>& trj, bool keep_seized) {
-  return XPtr<Leave<double> >(new Leave<double>(prob, trj, keep_seized));
+  return XPtr<Activity>(new Leave<double>(prob, trj, keep_seized));
 }
 
 //[[Rcpp::export]]
 SEXP HandleUnfinished__new(const std::vector<Environment>& trj) {
-  return XPtr<HandleUnfinished>(new HandleUnfinished(trj));
+  return XPtr<Activity>(new HandleUnfinished(trj));
 }
 
 //[[Rcpp::export]]
 SEXP Leave__new_func(const Function& prob, const std::vector<Environment>& trj, bool keep_seized) {
-  return XPtr<Leave<Function> >(new Leave<Function>(prob, trj, keep_seized));
+  return XPtr<Activity>(new Leave<Function>(prob, trj, keep_seized));
 }
 
 //[[Rcpp::export]]
 SEXP Clone__new(int n, const std::vector<Environment>& trj) {
-  return XPtr<Clone<int> >(new Clone<int>(n, trj));
+  return XPtr<Activity>(new Clone<int>(n, trj));
 }
 
 //[[Rcpp::export]]
 SEXP Clone__new_func(const Function& n, const std::vector<Environment>& trj) {
-  return XPtr<Clone<Function> >(new Clone<Function>(n, trj));
+  return XPtr<Activity>(new Clone<Function>(n, trj));
 }
 
 //[[Rcpp::export]]
 SEXP Synchronize__new(bool wait, bool terminate) {
-  return XPtr<Synchronize>(new Synchronize(wait, terminate));
+  return XPtr<Activity>(new Synchronize(wait, terminate));
 }
 
 //[[Rcpp::export]]
 SEXP Batch__new(int n, double timeout, bool permanent, const std::string& name) {
-  return XPtr<Batch<double> >(new Batch<double>(n, timeout, permanent, name));
+  return XPtr<Activity>(new Batch<double>(n, timeout, permanent, name));
 }
 
 //[[Rcpp::export]]
 SEXP Batch__new_func1(int n, const Function& timeout, bool permanent, const std::string& name) {
-  return XPtr<Batch<Function> >(new Batch<Function>(n, timeout, permanent, name));
+  return XPtr<Activity>(new Batch<Function>(n, timeout, permanent, name));
 }
 
 //[[Rcpp::export]]
 SEXP Batch__new_func2(int n, double timeout, bool permanent,
                       const std::string& name, const Function& rule)
 {
-  return XPtr<Batch<double> >(new Batch<double>(n, timeout, permanent, name, rule));
+  return XPtr<Activity>(new Batch<double>(n, timeout, permanent, name, rule));
 }
 
 //[[Rcpp::export]]
 SEXP Batch__new_func3(int n, const Function& timeout, bool permanent,
                       const std::string& name,const Function& rule)
 {
-  return XPtr<Batch<Function> >(new Batch<Function>(n, timeout, permanent, name, rule));
+  return XPtr<Activity>(new Batch<Function>(n, timeout, permanent, name, rule));
 }
 
 //[[Rcpp::export]]
-SEXP Separate__new() { return XPtr<Separate>(new Separate()); }
+SEXP Separate__new() { return XPtr<Activity>(new Separate()); }
 
 //[[Rcpp::export]]
 SEXP RenegeIn__new(double t, const std::vector<Environment>& trj, bool keep_seized) {
-  return XPtr<RenegeIn<double> >(new RenegeIn<double>(t, trj, keep_seized));
+  return XPtr<Activity>(new RenegeIn<double>(t, trj, keep_seized));
 }
 
 //[[Rcpp::export]]
 SEXP RenegeIn__new_func(const Function& t, const std::vector<Environment>& trj, bool keep_seized) {
-  return XPtr<RenegeIn<Function> >(new RenegeIn<Function>(t, trj, keep_seized));
+  return XPtr<Activity>(new RenegeIn<Function>(t, trj, keep_seized));
 }
 
 //[[Rcpp::export]]
 SEXP RenegeIf__new(const std::string& signal, const std::vector<Environment>& trj, bool keep_seized) {
-  return XPtr<RenegeIf<std::string> >(new RenegeIf<std::string>(signal, trj, keep_seized));
+  return XPtr<Activity>(new RenegeIf<std::string>(signal, trj, keep_seized));
 }
 
 //[[Rcpp::export]]
 SEXP RenegeIf__new_func(const Function& signal, const std::vector<Environment>& trj, bool keep_seized) {
-  return XPtr<RenegeIf<Function> >(new RenegeIf<Function>(signal, trj, keep_seized));
+  return XPtr<Activity>(new RenegeIf<Function>(signal, trj, keep_seized));
 }
 
 //[[Rcpp::export]]
-SEXP RenegeAbort__new() { return XPtr<RenegeAbort>(new RenegeAbort()); }
+SEXP RenegeAbort__new() { return XPtr<Activity>(new RenegeAbort()); }
 
 //[[Rcpp::export]]
 SEXP Send__new(const std::vector<std::string>& signals, double delay) {
-  return XPtr<Send<VEC<std::string>, double> >(
-      new Send<VEC<std::string>, double>(signals, delay));
+  return XPtr<Activity>(new Send<VEC<std::string>, double>(signals, delay));
 }
 
 //[[Rcpp::export]]
 SEXP Send__new_func1(const Function& signals, double delay) {
-  return XPtr<Send<Function, double> >(new Send<Function, double>(signals, delay));
+  return XPtr<Activity>(new Send<Function, double>(signals, delay));
 }
 
 //[[Rcpp::export]]
 SEXP Send__new_func2(const std::vector<std::string>& signals, const Function& delay) {
-  return XPtr<Send<VEC<std::string>, Function> >(
-      new Send<VEC<std::string>, Function>(signals, delay));
+  return XPtr<Activity>(new Send<VEC<std::string>, Function>(signals, delay));
 }
 
 //[[Rcpp::export]]
 SEXP Send__new_func3(const Function& signals, const Function& delay) {
-  return XPtr<Send<Function, Function> >(new Send<Function, Function>(signals, delay));
+  return XPtr<Activity>(new Send<Function, Function>(signals, delay));
 }
 
 //[[Rcpp::export]]
 SEXP Trap__new(const std::vector<std::string>& signals,
                const std::vector<Environment>& trj, bool interruptible)
 {
-  return XPtr<Trap<VEC<std::string> > >(
-      new Trap<VEC<std::string> >(signals, trj, interruptible));
+  return XPtr<Activity>(new Trap<VEC<std::string> >(signals, trj, interruptible));
 }
 
 //[[Rcpp::export]]
 SEXP Trap__new_func(const Function& signals,
                     const std::vector<Environment>& trj, bool interruptible)
 {
-  return XPtr<Trap<Function> >(new Trap<Function>(signals, trj, interruptible));
+  return XPtr<Activity>(new Trap<Function>(signals, trj, interruptible));
 }
 
 //[[Rcpp::export]]
 SEXP UnTrap__new(const std::vector<std::string>& signals) {
-  return XPtr<UnTrap<VEC<std::string> > >(new UnTrap<VEC<std::string> >(signals));
+  return XPtr<Activity>(new UnTrap<VEC<std::string> >(signals));
 }
 
 //[[Rcpp::export]]
 SEXP UnTrap__new_func(const Function& signals) {
-  return XPtr<UnTrap<Function> >(new UnTrap<Function>(signals));
+  return XPtr<Activity>(new UnTrap<Function>(signals));
 }
 
 //[[Rcpp::export]]
-SEXP Wait__new() { return XPtr<Wait>(new Wait()); }
+SEXP Wait__new() { return XPtr<Activity>(new Wait()); }
 
 //[[Rcpp::export]]
 SEXP Log__new(const std::string& message, int level) {
-  return XPtr<Log<std::string> >(new Log<std::string>(message, level));
+  return XPtr<Activity>(new Log<std::string>(message, level));
 }
 
 //[[Rcpp::export]]
 SEXP Log__new_func(const Function& message, int level) {
-  return XPtr<Log<Function> >(new Log<Function>(message, level));
+  return XPtr<Activity>(new Log<Function>(message, level));
 }
 
 //[[Rcpp::export]]
 SEXP StopIf__new(bool condition) {
-  return XPtr<StopIf<bool> >(new StopIf<bool>(condition));
+  return XPtr<Activity>(new StopIf<bool>(condition));
 }
 
 //[[Rcpp::export]]
 SEXP StopIf__new_func(const Function& condition) {
-  return XPtr<StopIf<Function> >(new StopIf<Function>(condition));
+  return XPtr<Activity>(new StopIf<Function>(condition));
 }
 
 //[[Rcpp::export]]


### PR DESCRIPTION
Fix memory issues in `trap()`, `synchronize()` and `rollback()`. These are stateful activities that require storing information about passing arrivals to manage clones or redirections. These activities were not properly cleaning their storage when arrivals were rejected at some point in the trajectory. As a result, certain simulations with these activities involved may show random improper behaviour depending on how memory reuse happens. This patch unifies storage management for stateful activities, adds a new interface to register these activities and another interface for arrivals to notify their termination, so that the stored information is properly cleaned up.