### PR TITLE
add support for variable batch sizes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         - {os: macOS-latest, r: 'devel'}
         - {os: macOS-latest, r: 'release'}
         - {os: windows-latest, r: 'release'}
-        - {os: ubuntu-latest, r: 'release'}
+        - {os: ubuntu-latest, r: 'release', covr: 'yes'}
         - {os: ubuntu-latest, r: 'oldrel'}
 
     env:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,9 @@
-# simmer 4.4.2.9000
+# simmer 4.4.3
 
 ## New features
 
-- Add support for functions in `when_activated` (#250).
+- Add support for functions in `when_activated()` (#250).
+- Add support for dynamic batch sizes (#258 addressing #245).
 
 ## Minor changes and fixes
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -205,12 +205,28 @@ Batch__new_func1 <- function(n, timeout, permanent, name) {
     .Call(`_simmer_Batch__new_func1`, n, timeout, permanent, name)
 }
 
-Batch__new_func2 <- function(n, timeout, permanent, name, rule) {
-    .Call(`_simmer_Batch__new_func2`, n, timeout, permanent, name, rule)
+Batch__new_func2 <- function(n, timeout, permanent, name) {
+    .Call(`_simmer_Batch__new_func2`, n, timeout, permanent, name)
 }
 
-Batch__new_func3 <- function(n, timeout, permanent, name, rule) {
-    .Call(`_simmer_Batch__new_func3`, n, timeout, permanent, name, rule)
+Batch__new_func3 <- function(n, timeout, permanent, name) {
+    .Call(`_simmer_Batch__new_func3`, n, timeout, permanent, name)
+}
+
+Batch__new_func4 <- function(n, timeout, permanent, name, rule) {
+    .Call(`_simmer_Batch__new_func4`, n, timeout, permanent, name, rule)
+}
+
+Batch__new_func5 <- function(n, timeout, permanent, name, rule) {
+    .Call(`_simmer_Batch__new_func5`, n, timeout, permanent, name, rule)
+}
+
+Batch__new_func6 <- function(n, timeout, permanent, name, rule) {
+    .Call(`_simmer_Batch__new_func6`, n, timeout, permanent, name, rule)
+}
+
+Batch__new_func7 <- function(n, timeout, permanent, name, rule) {
+    .Call(`_simmer_Batch__new_func7`, n, timeout, permanent, name, rule)
 }
 
 Separate__new <- function() {

--- a/R/trajectory-activities.R
+++ b/R/trajectory-activities.R
@@ -1139,7 +1139,8 @@ synchronize.trajectory <- function(.trj, wait=TRUE, mon_all=FALSE) {
 #' and splitting a previously established batch.
 #'
 #' @inheritParams seize
-#' @param n batch size, accepts a numeric.
+#' @param n batch size, accepts a numeric or a callable object (a function)
+#' which must return a numeric.
 #' @param timeout set an optional timer which triggers batches every
 #' \code{timeout} time units even if the batch size has not been fulfilled,
 #' accepts a numeric or a callable object (a function) which must return a
@@ -1208,15 +1209,19 @@ batch <- function(.trj, n, timeout=0, permanent=FALSE, name="", rule=NULL)
 
 #' @export
 batch.trajectory <- function(.trj, n, timeout=0, permanent=FALSE, name="", rule=NULL) {
-  check_args(n="numeric", timeout=c("numeric", "function"), permanent="flag",
-             name="character", rule=c("function", "NULL"))
+  check_args(n=c("numeric", "function"), timeout=c("numeric", "function"),
+             permanent="flag", name="character", rule=c("function", "NULL"))
 
   switch(
-    binarise(is.function(timeout), is.function(rule)),
+    binarise(is.function(n), is.function(timeout), is.function(rule)),
     add_activity(.trj, Batch__new(positive(n), timeout, permanent, name)),
-    add_activity(.trj, Batch__new_func1(positive(n), timeout, permanent, name)),
-    add_activity(.trj, Batch__new_func2(positive(n), timeout, permanent, name, rule)),
-    add_activity(.trj, Batch__new_func3(positive(n), timeout, permanent, name, rule))
+    add_activity(.trj, Batch__new_func1(n, timeout, permanent, name)),
+    add_activity(.trj, Batch__new_func2(positive(n), timeout, permanent, name)),
+    add_activity(.trj, Batch__new_func3(n, timeout, permanent, name)),
+    add_activity(.trj, Batch__new_func4(positive(n), timeout, permanent, name, rule)),
+    add_activity(.trj, Batch__new_func5(n, timeout, permanent, name, rule)),
+    add_activity(.trj, Batch__new_func6(positive(n), timeout, permanent, name, rule)),
+    add_activity(.trj, Batch__new_func7(n, timeout, permanent, name, rule))
   )
 }
 

--- a/inst/include/simmer/process/batched.h
+++ b/inst/include/simmer/process/batched.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016-2019 Iñaki Ucar
+// Copyright (C) 2016-2019,2021 Iñaki Ucar
 //
 // This file is part of simmer.
 //
@@ -29,8 +29,8 @@ namespace simmer {
   public:
     CLONEABLE(Batched)
 
-    Batched(Simulator* sim, const std::string& name, bool permanent, int priority = 0)
-      : Arrival(sim, name, true, Order(), NULL, priority), permanent(permanent) {}
+    Batched(Simulator* sim, const std::string& name, int n, bool permanent, int priority = 0)
+      : Arrival(sim, name, true, Order(), NULL, priority), n(n), permanent(permanent) {}
 
     Batched(const Batched& o) : Arrival(o), arrivals(o.arrivals), permanent(o.permanent) {
       for (size_t i=0; i<arrivals.size(); i++) {
@@ -68,8 +68,11 @@ namespace simmer {
     }
 
     size_t size() const { return arrivals.size(); }
+    int max_size() const { return n; }
 
     void insert(Arrival* arrival) {
+      if ((int)arrivals.size() == n)
+        Rcpp::stop("cannot insert into '%s', max. capacity %d reached", name, n); // # nocov
       arrival->set_activity(NULL);
       arrivals.push_back(arrival);
       arrival->register_entity(this);
@@ -103,6 +106,7 @@ namespace simmer {
 
   private:
     VEC<Arrival*> arrivals;
+    int n;
     bool permanent;
 
     void reset() {

--- a/man/batch.Rd
+++ b/man/batch.Rd
@@ -12,7 +12,8 @@ separate(.trj)
 \arguments{
 \item{.trj}{the trajectory object.}
 
-\item{n}{batch size, accepts a numeric.}
+\item{n}{batch size, accepts a numeric or a callable object (a function)
+which must return a numeric.}
 
 \item{timeout}{set an optional timer which triggers batches every
 \code{timeout} time units even if the batch size has not been fulfilled,

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -640,13 +640,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // Batch__new_func1
-SEXP Batch__new_func1(int n, const Function& timeout, bool permanent, const std::string& name);
+SEXP Batch__new_func1(const Function& n, double timeout, bool permanent, const std::string& name);
 RcppExport SEXP _simmer_Batch__new_func1(SEXP nSEXP, SEXP timeoutSEXP, SEXP permanentSEXP, SEXP nameSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< int >::type n(nSEXP);
-    Rcpp::traits::input_parameter< const Function& >::type timeout(timeoutSEXP);
+    Rcpp::traits::input_parameter< const Function& >::type n(nSEXP);
+    Rcpp::traits::input_parameter< double >::type timeout(timeoutSEXP);
     Rcpp::traits::input_parameter< bool >::type permanent(permanentSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type name(nameSEXP);
     rcpp_result_gen = Rcpp::wrap(Batch__new_func1(n, timeout, permanent, name));
@@ -654,8 +654,36 @@ BEGIN_RCPP
 END_RCPP
 }
 // Batch__new_func2
-SEXP Batch__new_func2(int n, double timeout, bool permanent, const std::string& name, const Function& rule);
-RcppExport SEXP _simmer_Batch__new_func2(SEXP nSEXP, SEXP timeoutSEXP, SEXP permanentSEXP, SEXP nameSEXP, SEXP ruleSEXP) {
+SEXP Batch__new_func2(int n, const Function& timeout, bool permanent, const std::string& name);
+RcppExport SEXP _simmer_Batch__new_func2(SEXP nSEXP, SEXP timeoutSEXP, SEXP permanentSEXP, SEXP nameSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< int >::type n(nSEXP);
+    Rcpp::traits::input_parameter< const Function& >::type timeout(timeoutSEXP);
+    Rcpp::traits::input_parameter< bool >::type permanent(permanentSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type name(nameSEXP);
+    rcpp_result_gen = Rcpp::wrap(Batch__new_func2(n, timeout, permanent, name));
+    return rcpp_result_gen;
+END_RCPP
+}
+// Batch__new_func3
+SEXP Batch__new_func3(const Function& n, const Function& timeout, bool permanent, const std::string& name);
+RcppExport SEXP _simmer_Batch__new_func3(SEXP nSEXP, SEXP timeoutSEXP, SEXP permanentSEXP, SEXP nameSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Function& >::type n(nSEXP);
+    Rcpp::traits::input_parameter< const Function& >::type timeout(timeoutSEXP);
+    Rcpp::traits::input_parameter< bool >::type permanent(permanentSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type name(nameSEXP);
+    rcpp_result_gen = Rcpp::wrap(Batch__new_func3(n, timeout, permanent, name));
+    return rcpp_result_gen;
+END_RCPP
+}
+// Batch__new_func4
+SEXP Batch__new_func4(int n, double timeout, bool permanent, const std::string& name, const Function& rule);
+RcppExport SEXP _simmer_Batch__new_func4(SEXP nSEXP, SEXP timeoutSEXP, SEXP permanentSEXP, SEXP nameSEXP, SEXP ruleSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -664,13 +692,28 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type permanent(permanentSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type name(nameSEXP);
     Rcpp::traits::input_parameter< const Function& >::type rule(ruleSEXP);
-    rcpp_result_gen = Rcpp::wrap(Batch__new_func2(n, timeout, permanent, name, rule));
+    rcpp_result_gen = Rcpp::wrap(Batch__new_func4(n, timeout, permanent, name, rule));
     return rcpp_result_gen;
 END_RCPP
 }
-// Batch__new_func3
-SEXP Batch__new_func3(int n, const Function& timeout, bool permanent, const std::string& name, const Function& rule);
-RcppExport SEXP _simmer_Batch__new_func3(SEXP nSEXP, SEXP timeoutSEXP, SEXP permanentSEXP, SEXP nameSEXP, SEXP ruleSEXP) {
+// Batch__new_func5
+SEXP Batch__new_func5(const Function& n, double timeout, bool permanent, const std::string& name, const Function& rule);
+RcppExport SEXP _simmer_Batch__new_func5(SEXP nSEXP, SEXP timeoutSEXP, SEXP permanentSEXP, SEXP nameSEXP, SEXP ruleSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Function& >::type n(nSEXP);
+    Rcpp::traits::input_parameter< double >::type timeout(timeoutSEXP);
+    Rcpp::traits::input_parameter< bool >::type permanent(permanentSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type name(nameSEXP);
+    Rcpp::traits::input_parameter< const Function& >::type rule(ruleSEXP);
+    rcpp_result_gen = Rcpp::wrap(Batch__new_func5(n, timeout, permanent, name, rule));
+    return rcpp_result_gen;
+END_RCPP
+}
+// Batch__new_func6
+SEXP Batch__new_func6(int n, const Function& timeout, bool permanent, const std::string& name, const Function& rule);
+RcppExport SEXP _simmer_Batch__new_func6(SEXP nSEXP, SEXP timeoutSEXP, SEXP permanentSEXP, SEXP nameSEXP, SEXP ruleSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -679,7 +722,22 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type permanent(permanentSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type name(nameSEXP);
     Rcpp::traits::input_parameter< const Function& >::type rule(ruleSEXP);
-    rcpp_result_gen = Rcpp::wrap(Batch__new_func3(n, timeout, permanent, name, rule));
+    rcpp_result_gen = Rcpp::wrap(Batch__new_func6(n, timeout, permanent, name, rule));
+    return rcpp_result_gen;
+END_RCPP
+}
+// Batch__new_func7
+SEXP Batch__new_func7(const Function& n, const Function& timeout, bool permanent, const std::string& name, const Function& rule);
+RcppExport SEXP _simmer_Batch__new_func7(SEXP nSEXP, SEXP timeoutSEXP, SEXP permanentSEXP, SEXP nameSEXP, SEXP ruleSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Function& >::type n(nSEXP);
+    Rcpp::traits::input_parameter< const Function& >::type timeout(timeoutSEXP);
+    Rcpp::traits::input_parameter< bool >::type permanent(permanentSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type name(nameSEXP);
+    Rcpp::traits::input_parameter< const Function& >::type rule(ruleSEXP);
+    rcpp_result_gen = Rcpp::wrap(Batch__new_func7(n, timeout, permanent, name, rule));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1450,8 +1508,12 @@ static const R_CallMethodDef CallEntries[] = {
     {"_simmer_Synchronize__new", (DL_FUNC) &_simmer_Synchronize__new, 2},
     {"_simmer_Batch__new", (DL_FUNC) &_simmer_Batch__new, 4},
     {"_simmer_Batch__new_func1", (DL_FUNC) &_simmer_Batch__new_func1, 4},
-    {"_simmer_Batch__new_func2", (DL_FUNC) &_simmer_Batch__new_func2, 5},
-    {"_simmer_Batch__new_func3", (DL_FUNC) &_simmer_Batch__new_func3, 5},
+    {"_simmer_Batch__new_func2", (DL_FUNC) &_simmer_Batch__new_func2, 4},
+    {"_simmer_Batch__new_func3", (DL_FUNC) &_simmer_Batch__new_func3, 4},
+    {"_simmer_Batch__new_func4", (DL_FUNC) &_simmer_Batch__new_func4, 5},
+    {"_simmer_Batch__new_func5", (DL_FUNC) &_simmer_Batch__new_func5, 5},
+    {"_simmer_Batch__new_func6", (DL_FUNC) &_simmer_Batch__new_func6, 5},
+    {"_simmer_Batch__new_func7", (DL_FUNC) &_simmer_Batch__new_func7, 5},
     {"_simmer_Separate__new", (DL_FUNC) &_simmer_Separate__new, 0},
     {"_simmer_RenegeIn__new", (DL_FUNC) &_simmer_RenegeIn__new, 3},
     {"_simmer_RenegeIn__new_func", (DL_FUNC) &_simmer_RenegeIn__new_func, 3},

--- a/src/activity.cpp
+++ b/src/activity.cpp
@@ -1,6 +1,6 @@
 // Copyright (C) 2014 Bart Smeets
 // Copyright (C) 2015 Iñaki Ucar and Bart Smeets
-// Copyright (C) 2015-2020 Iñaki Ucar
+// Copyright (C) 2015-2021 Iñaki Ucar
 //
 // This file is part of simmer.
 //
@@ -293,26 +293,56 @@ SEXP Synchronize__new(bool wait, bool terminate) {
 
 //[[Rcpp::export]]
 SEXP Batch__new(int n, double timeout, bool permanent, const std::string& name) {
-  return XPtr<Activity>(new Batch<double>(n, timeout, permanent, name));
+  return XPtr<Activity>(new Batch<int, double>(n, timeout, permanent, name));
 }
 
 //[[Rcpp::export]]
-SEXP Batch__new_func1(int n, const Function& timeout, bool permanent, const std::string& name) {
-  return XPtr<Activity>(new Batch<Function>(n, timeout, permanent, name));
+SEXP Batch__new_func1(const Function& n, double timeout, bool permanent,
+                      const std::string& name)
+{
+  return XPtr<Activity>(new Batch<Function, double>(n, timeout, permanent, name));
 }
 
 //[[Rcpp::export]]
-SEXP Batch__new_func2(int n, double timeout, bool permanent,
+SEXP Batch__new_func2(int n, const Function& timeout, bool permanent,
+                      const std::string& name)
+{
+  return XPtr<Activity>(new Batch<int, Function>(n, timeout, permanent, name));
+}
+
+//[[Rcpp::export]]
+SEXP Batch__new_func3(const Function& n, const Function& timeout, bool permanent,
+                      const std::string& name)
+{
+  return XPtr<Activity>(new Batch<Function, Function>(n, timeout, permanent, name));
+}
+
+//[[Rcpp::export]]
+SEXP Batch__new_func4(int n, double timeout, bool permanent,
                       const std::string& name, const Function& rule)
 {
-  return XPtr<Activity>(new Batch<double>(n, timeout, permanent, name, rule));
+  return XPtr<Activity>(new Batch<int, double>(n, timeout, permanent, name, rule));
 }
 
 //[[Rcpp::export]]
-SEXP Batch__new_func3(int n, const Function& timeout, bool permanent,
-                      const std::string& name,const Function& rule)
+SEXP Batch__new_func5(const Function& n, double timeout, bool permanent,
+                      const std::string& name, const Function& rule)
 {
-  return XPtr<Activity>(new Batch<Function>(n, timeout, permanent, name, rule));
+  return XPtr<Activity>(new Batch<Function, double>(n, timeout, permanent, name, rule));
+}
+
+//[[Rcpp::export]]
+SEXP Batch__new_func6(int n, const Function& timeout, bool permanent,
+                      const std::string& name, const Function& rule)
+{
+  return XPtr<Activity>(new Batch<int, Function>(n, timeout, permanent, name, rule));
+}
+
+//[[Rcpp::export]]
+SEXP Batch__new_func7(const Function& n, const Function& timeout, bool permanent,
+                      const std::string& name, const Function& rule)
+{
+  return XPtr<Activity>(new Batch<Function, Function>(n, timeout, permanent, name, rule));
 }
 
 //[[Rcpp::export]]

--- a/tests/testthat/test-trajectory-batch-separate.R
+++ b/tests/testthat/test-trajectory-batch-separate.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2017,2019 Iñaki Ucar
+# Copyright (C) 2016-2017,2019,2021 Iñaki Ucar
 #
 # This file is part of simmer.
 #
@@ -78,7 +78,7 @@ test_that("batches are separated", {
 
 test_that("permanent batches are NOT separated", {
   t <- trajectory(verbose = TRUE) %>%
-    batch(2, timeout = 0, permanent = TRUE, rule = NULL) %>%
+    batch(function() 2, timeout = 0, permanent = TRUE, rule = NULL) %>%
     seize("dummy", 1) %>%
     timeout(1) %>%
     release("dummy", 1) %>%
@@ -128,7 +128,7 @@ test_that("a rule can prevent batching", {
 
 test_that("a timeout can trigger early batches", {
   t <- trajectory(verbose = TRUE) %>%
-    batch(2, timeout = 0.5, permanent = FALSE, rule = NULL) %>%
+    batch(function() 2, timeout = function() 0.5, permanent = FALSE, rule = NULL) %>%
     seize("dummy", 1) %>%
     timeout(1) %>%
     release("dummy", 1) %>%

--- a/tests/testthat/test-trajectory.R
+++ b/tests/testthat/test-trajectory.R
@@ -1,5 +1,5 @@
 # Copyright (C) 2015-2016 Iñaki Ucar and Bart Smeets
-# Copyright (C) 2016-2018 Iñaki Ucar
+# Copyright (C) 2016-2018,2021 Iñaki Ucar
 #
 # This file is part of simmer.
 #
@@ -41,6 +41,8 @@ t0 <- trajectory(verbose = TRUE) %>%
   clone(function() 2, trajectory(verbose = TRUE) %>% timeout(1)) %>%
   synchronize() %>%
   batch(1, rule = function() 0) %>%
+  batch(function() 1, rule = function() 0) %>%
+  batch(function() 1, function() 0, rule = function() 0) %>%
   separate() %>%
   renege_in(function() 1, trajectory(verbose = TRUE) %>% timeout(1)) %>%
   renege_if(function() "1", trajectory(verbose = TRUE) %>% timeout(1)) %>%
@@ -84,6 +86,8 @@ trajs <- c(
                                        trajectory(verbose = TRUE) %>% timeout(1)),
   trajectory(verbose = TRUE) %>% synchronize(),
   trajectory(verbose = TRUE) %>% batch(1, rule = function() 0),
+  trajectory(verbose = TRUE) %>% batch(function() 1, rule = function() 0),
+  trajectory(verbose = TRUE) %>% batch(function() 1, function() 0, rule = function() 0),
   trajectory(verbose = TRUE) %>% separate(),
   trajectory(verbose = TRUE) %>% renege_in(function() 1,
                                            trajectory(verbose = TRUE) %>% timeout(1)),


### PR DESCRIPTION
Enhance batch interface to accept a function as parameter `n`. This max size is evaluated with the first arrival initiating the batch and stored in the `Batched` object, which ensures that this limit is not exceeded.

Closes #245.