### PR TITLE
Small Bank vignette corrections

### DIFF
--- a/vignettes/simmer-04-bank-1.Rmd
+++ b/vignettes/simmer-04-bank-1.Rmd
@@ -517,7 +517,7 @@ been demonstrated.  Here, we simply summarise the data frame returned by the
 `get_mon_arrivals` function, using standard R functions.
 
 We also increase the number of customers to 50 (find the number '49' in the
-code.code).
+code).
 
 ```{r, message = FALSE}
 library(simmer)

--- a/vignettes/simmer-04-bank-2.Rmd
+++ b/vignettes/simmer-04-bank-2.Rmd
@@ -205,7 +205,7 @@ bank <-
 
 bank %>% run(until = maxTime)
 
-number_balked <- sum(!get_mon_arrivals(bank)$finished)
+number_balked <- sum(get_mon_arrivals(bank)$activity_time == 0)
 paste("Balking rate is", number_balked / now(bank), "customers per minute.")
 ```
 


### PR DESCRIPTION
Two changes:

1. Typo in the first bank vignette.
2. The code to calculate `number_balked` yields 0, when five customers balk in the log. When a customer balks, their `activity_time` is 0, so I used this to count the number of balks. Maybe there is a better way to calculate this.